### PR TITLE
remove faulty platform

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -110,7 +110,7 @@ jobs:
             BUILD_VERSION=${{ steps.read_version.outputs.version }}
           
           # *** Define all platforms to build ***
-          platforms: linux/amd64,linux/arm64,linux/ppc64
+          platforms: linux/amd64,linux/arm64
 
           # *** Add caching to speed up builds ***
           cache-from: type=gha


### PR DESCRIPTION
GH workflow was targeting a faulty platform. Removed it and left just the ones needed.