### PR TITLE
ci: autobump versions of containers

### DIFF
--- a/.github/scripts/bump_versions.py
+++ b/.github/scripts/bump_versions.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+
+"""
+Automatic Version Bumper
+
+This script is designed to be run in a GitHub Action.
+It compares the PR branch with its base branch, finds modified
+container image directories, and bumps their 'VERSION' file
+based on conventional commit messages.
+
+It respects manual bumps: if a user manually bumps a version
+higher than what the commits would suggest, it leaves it alone.
+
+Requires 'semver' library: pip install semver
+"""
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from enum import IntEnum
+
+# --- Constants ---
+
+# Conventional Commit regex patterns
+# We look for the scope matching the directory name
+MAJOR_REGEX = r"(feat|fix)\((.+)\)!:"
+BREAKING_REGEX = r"BREAKING CHANGE"
+MINOR_REGEX = r"feat\((.+)\):"
+PATCH_REGEX = r"fix\((.+)\):"
+
+# --- Enums for Bump Logic ---
+
+class BumpLevel(IntEnum):
+    NONE = 0
+    PATCH = 1
+    MINOR = 2
+    MAJOR = 3
+
+    def __gt__(self, other):
+        if self.__class__ is other.__class__:
+            return self.value > other.value
+        return NotImplemented
+
+
+# --- Git Helper Functions ---
+
+def run_git_command(cmd: list[str]) -> str:
+    """Runs a git command and returns its stdout."""
+    try:
+        result = subprocess.run(
+            ["git"] + cmd,
+            capture_output=True,
+            text=True,
+            check=True,
+            encoding="utf-8",
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        print(f"Error running git command: {' '.join(cmd)}", file=sys.stderr)
+        print(f"STDERR: {e.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+
+def get_changed_files(base_ref: str, head_ref: str, directory: Path) -> list[str]:
+    """Get a list of non-documentation files changed in a directory."""
+    cmd = ["diff", "--name-only", base_ref, head_ref, "--", str(directory)]
+    all_files = run_git_command(cmd).splitlines()
+    
+    # Filter out documentation files, mirroring publish-images.yml
+    return [
+        f for f in all_files 
+        if not (f.endswith(".md") or f.endswith("README.md"))
+    ]
+
+
+def get_commit_logs(base_ref: str, head_ref: str, directory: Path) -> str:
+    """Get all commit messages that touched a given directory."""
+    # We use a rare delimiter to safely split commits
+    delimiter = "----COMMIT-DELIMITER----"
+    cmd = [
+        "log",
+        f"{base_ref}..{head_ref}",
+        f"--pretty=format:%B%n%n{delimiter}",
+        "--",
+        str(directory),
+    ]
+    return run_git_command(cmd)
+
+def get_base_version(base_ref: str, version_file: Path) -> str:
+    """Get the version from the base branch.
+    If the file doesn't exist, return '0.0.0'.
+    """
+    try:
+        return run_git_command(["show", f"{base_ref}:{version_file}"])
+    except subprocess.CalledProcessError as e:
+        # This will happen if the file is new in this PR
+        print(f"File {version_file} not found on base branch. Assuming 0.0.0")
+        return "0.0.0"
+
+# --- Main Logic ---
+
+def main():
+    try:
+        # 'semver' is a required dependency
+        import semver
+    except ImportError:
+        print("Error: 'semver' library not found.", file=sys.stderr)
+        print("Please install it: pip install semver", file=sys.stderr)
+        sys.exit(1)
+
+    base_ref = os.environ.get("BASE_REF")
+    head_ref = os.environ.get("HEAD_REF")
+
+    if not base_ref or not head_ref:
+        print("Error: BASE_REF and HEAD_REF env variables are required.", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Checking for bumps between {base_ref} and {head_ref}...\n")
+    
+    # Find all directories with a Containerfile AND a VERSION file
+    # (as defined in the user's prompt)
+    root = Path(".")
+    image_dirs = [
+        p.parent
+        for p in root.glob("*/VERSION")
+        if (p.parent / "Containerfile").exists()
+    ]
+    
+    commit_made = False
+
+    for directory in image_dirs:
+        scope = directory.name
+        version_file = directory / "VERSION"
+        print(f"--- Processing: {scope} ---")
+
+        # 1. Check for relevant (non-doc) changes
+        changed_files = get_changed_files(base_ref, head_ref, directory)
+        if not changed_files:
+            print("No non-documentation changes found. Skipping.")
+            continue
+
+        print(f"Found {len(changed_files)} changed file(s): {changed_files[0]}...")
+
+        # 2. Find the highest bump level from commits
+        highest_bump = BumpLevel.NONE
+        raw_logs = get_commit_logs(base_ref, head_ref, directory)
+        commits = raw_logs.split("----COMMIT-DELIMITER----")
+
+        for commit_msg in commits:
+            if not commit_msg:
+                continue
+
+            # Check for Major
+            if (
+                re.search(MAJOR_REGEX, commit_msg, re.M)
+                or re.search(BREAKING_REGEX, commit_msg, re.M)
+            ):
+                # Check if the scope matches our directory
+                if re.search(f"(feat|fix)\({scope}\)!:", commit_msg) or re.search(BREAKING_REGEX, commit_msg, re.M):
+                   highest_bump = BumpLevel.MAJOR
+                
+            # Check for Minor (if not already major)
+            if highest_bump < BumpLevel.MAJOR:
+                if re.search(f"feat\({scope}\):", commit_msg):
+                    highest_bump = max(highest_bump, BumpLevel.MINOR)
+            
+            # Check for Patch (if not already minor or major)
+            if highest_bump < BumpLevel.MINOR:
+                if re.search(f"fix\({scope}\):", commit_msg):
+                    highest_bump = max(highest_bump, BumpLevel.PATCH)
+
+        if highest_bump == BumpLevel.NONE:
+            print("No conventional commits found. Skipping.")
+            continue
+
+        print(f"Found highest bump type: {highest_bump.name}")
+
+        # 3. Get versions
+        try:
+            base_version_str = get_base_version(base_ref, version_file)
+            base_v = semver.VersionInfo.parse(base_version_str)
+            
+            pr_version_str = version_file.read_text().strip()
+            pr_v = semver.VersionInfo.parse(pr_version_str)
+        except (ValueError, FileNotFoundError) as e:
+            print(f"Error parsing version for {scope}: {e}", file=sys.stderr)
+            continue
+        
+        # 4. Calculate target version
+        if highest_bump == BumpLevel.MAJOR:
+            target_v = base_v.bump_major()
+        elif highest_bump == BumpLevel.MINOR:
+            target_v = base_v.bump_minor()
+        else: # Patch
+            target_v = base_v.bump_patch()
+
+        print(f"Base: {base_v} | PR: {pr_v} | Target: {target_v}")
+
+        # 5. Compare and write file
+        # This is the crucial logic you asked about.
+        if pr_v < target_v:
+            print(f"Bumping {scope}: {pr_v} -> {target_v}")
+            version_file.write_text(f"{target_v}\n")
+            commit_made = True
+        elif pr_v > target_v:
+            print(f"Respecting manual bump: PR version {pr_v} > target {target_v}")
+        else:
+            print(f"Version {pr_v} is already correct.")
+
+    print("---")
+    
+    # 6. Set GitHub Action output
+    if "GITHUB_OUTPUT" in os.environ:
+        with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+            f.write(f"commit_made={str(commit_made).lower()}\n")
+    print(f"Commit made: {commit_made}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/autobump-versions.yml
+++ b/.github/workflows/autobump-versions.yml
@@ -1,0 +1,59 @@
+# .github/workflows/autobump-versions.yml
+name: ⬆️ Autobump Image Versions
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# This action needs to write back to the PR branch
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  autobump:
+    name: 🤖 Bump Version
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: ⬇️ Checkout PR Branch
+        uses: actions/checkout@v4
+        with:
+          # Check out the PR branch (github.head_ref)
+          ref: ${{ github.head_ref }}
+          # Fetch full history to be able to diff against the base branch
+          fetch-depth: 0
+
+      - name: ⚙️ Configure Git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: 🐍 Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: 📦 Install Python Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install semver
+
+      - name: ⚡ Run Version Bump Script
+        id: bump_script
+        run: |
+          python .github/scripts/bump_versions.py
+        env:
+          # Set env vars for the script
+          BASE_REF: "origin/${{ github.base_ref }}"
+          HEAD_REF: "origin/${{ github.head_ref }}"
+
+      - name: ⬆️ Commit and Push Changes
+        if: steps.bump_script.outputs.commit_made == 'true'
+        run: |
+          echo "Committing and pushing version bumps..."
+          # Add all VERSION files that were modified
+          git add ./**/VERSION
+          git commit -m "chore: automatic version bumps [skip ci]"
+          # Push to the PR branch (HEAD)
+          git push origin HEAD:${{ github.head_ref }}


### PR DESCRIPTION
removes the need to manage (and remember to change) VERSION files for container images.

If changes are detected and the commit message is correct the version will be bumped to the correct level automatically.

Use a commit message prefix of;

- `fix(scope):` to bump a patch version
- `feat(scope):` to bump a minor version
- `feat(scope)!:` to bump a major version

Biggest change wins if there are multiple and the VERSION file can also be manually adjusted if needed.
