### PR TITLE
chore: prefix semver with 'v'

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 `ha-sinkhole` is a project that enables the highly available deployment of DNS sinkhole servers. It has similar aims to the DNS and Blocklist features of the popular `pi-hole` project.
 
-The project is a mono-repo consisting of a number of container image builds and some supporting scripts and files. Container builds are directories housing a `Containerfile` and a `VERSION` file. Each container is versioned independently of the project releases and each other. The current semantic version of each container is held in the `VERSION` file in the root of the container image context directory.
+The project is a mono-repo consisting of a number of container image builds and some supporting scripts and files. Container builds are directories housing a `Containerfile` and a `VERSION` file. Each container is versioned independently of the project releases and each other. The current semantic version of each container is held in the `VERSION` file in the root of the container image context directory as clean semver (e.g., `0.3.1`). When published, container images are tagged with a 'v' prefix (e.g., `v0.3.1`) following common container tagging conventions.
 
 The project prefers and recommends the use of `podman` and OCI specifications over `docker` and all code and suggestions should reflect this. However, `docker` as a container build or runtime technology should work.
 

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -147,6 +147,11 @@ jobs:
         run: |
           echo "version=$(cat ${{ matrix.service }}/VERSION)" >> $GITHUB_OUTPUT
 
+      - name: Create v-prefixed version for tags
+        id: version_tag
+        run: |
+          echo "vtag=v$(cat ${{ matrix.service }}/VERSION)" >> $GITHUB_OUTPUT
+
       - name: Read description from Containerfile
         id: extract_description
         run: |
@@ -160,8 +165,8 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}/${{ matrix.service }}
           tags: |
-            # Tag with the version from the VERSION file
-            type=raw,value=${{ steps.read_version.outputs.version }}
+            # Tag with the v-prefixed version from the VERSION file
+            type=raw,value=${{ steps.version_tag.outputs.vtag }}
             # If this is a push to 'main', also tag as 'latest'
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ Take a look through any open issues to see what things are a priority, and what 
 ## Developing and building the container images
 This project contains multiple container images (each in its own immediate sub-directory) and provides a `Makefile` to discover and build them. You'll need your distro's version of build tools installed to be able to run `make` and get local builds of the images for faster dev/test cycles.
 
-Each build image has its own `VERSION` file with the current semantic version number of the image in it. This file is updated automatically by github action workflows based on the commit message and the files that have been modified in the commit. You should rarely need to change this manually but it relies on adherance to the [coding rules](#coding-style) in order to work.
+Each build image has its own `VERSION` file with the current semantic version number of the image in it (e.g., `0.3.1`). When container images are published, they are tagged with a 'v' prefix (e.g., `v0.3.1`) following common container tagging conventions. The VERSION file is updated automatically by github action workflows based on the commit message and the files that have been modified in the commit. You should rarely need to change this manually but it relies on adherance to the [coding rules](#coding-style) in order to work.
 
 ### Building all images locally
 From the project root..
@@ -114,7 +114,7 @@ ansible-playbook -i ../.local/inventory.yaml playbooks/install.yaml
 ## Adding a new image
 1. Create a new immediate sub-directory under the repository root (e.g., `./my-component/`).
 2. Add a `Containerfile` (don't use `Dockerfile`) in that directory.
-3. Add a `VERSION` file with the initial version number for the component
+3. Add a `VERSION` file with the initial version number for the component (e.g., `0.1.0` without a 'v' prefix)
 4. Add the build arg and the 4 OCI labels
 ```Dockerfile
   ARG BUILD_VERSION

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -18,16 +18,16 @@
 
 stable:
   # Component versions guaranteed to work together after integration testing.
-  dns-node: "0.3.1"
-  stats-collector: "0.1.4"
-  vip-manager: "0.1.7"
-  blocklist-updater: "0.1.4"
-  installer: "0.5.3"
+  dns-node: "v0.3.1"
+  stats-collector: "v0.1.4"
+  vip-manager: "v0.1.7"
+  blocklist-updater: "v0.1.4"
+  installer: "v0.5.3"
 
 edge:
   # Latest published component versions used for pre-release testing.
-  dns-node: "0.3.1"
-  stats-collector: "0.1.4"
-  vip-manager: "0.1.7"
-  blocklist-updater: "0.1.4"
-  installer: "0.5.3"
+  dns-node: "v0.3.1"
+  stats-collector: "v0.1.4"
+  vip-manager: "v0.1.7"
+  blocklist-updater: "v0.1.4"
+  installer: "v0.5.3"


### PR DESCRIPTION
- Update docs and github workflow code to enable image tags using a 'v' prefix. This is a more idiomatic
approach to container versioning
- Closes #76
