### PR TITLE
fix(installer)!: add macOS compatibility with native mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,22 @@ Whether you're installing on a raspberry pi, a bare metal server, a local VM, on
 
 Both controller and the target machines you want to install components on need to meet some criteria:
 
-1. Your controller machine has an up to date `linux` distro or MacOS (it may work with Windows but I've no idea).
-2. You have a container management application installed on that same machine. [podman](https://podman.io/) is strongly recommended, [docker](https://www.docker.com/) should also just work. Install it using your distro's packaging tool.
-3. You have added your SSH key to a local `ssh-agent` with `ssh-add` on the controller node and the `SSH_AUTH_SOCK` environment variable is set (check by running `env | grep SSH`)
-4. You have one or more target nodes to deploy `ha-sinkhole` components to and these also have suitable and modern operating systems (Linux, RasPi, MacOS)
-5. You can SSH to each of your target nodes and your user can gain `root` with `sudo`.
+**Controller machine (where you run the installer):**
 
-The installation makes use of passwordless SSH and being able to become root on the target nodes in order to perform any install or uninstall task, so you will need to set these up first if you don't already have them working.
+1. An up-to-date `linux` distro or macOS (Windows compatibility unknown)
+2. Container runtime installed: [podman](https://podman.io/) (recommended) or [docker](https://www.docker.com/)
+3. SSH agent running with your key loaded: `ssh-add ~/.ssh/id_ed25519` (verify with `ssh-add -l`)
+4. Environment variable `SSH_AUTH_SOCK` is set (verify with `env | grep SSH`)
+5. **macOS only:** Install Ansible natively with `pipx install ansible-core` (container mode has limitations on macOS)
+
+**Target nodes (where components will be installed):**
+
+1. Modern Linux OS (also works on RasPi, macOS)
+2. SSH access configured - you can SSH to each node
+3. Your user can become root with `sudo` **without a password prompt**
+   - Configure with: `echo "$USER ALL=(ALL) NOPASSWD: ALL" | sudo tee /etc/sudoers.d/$USER`
+
+The installation makes use of passwordless SSH and passwordless sudo on the target nodes in order to perform any install or uninstall task, so you will need to set these up first if you don't already have them working.
 
 # ⏩ Quick Start Guide
 
@@ -79,9 +88,16 @@ Below is an example config to get 2 remote nodes installed (accessible at `192.1
 
 Once you have your inventory (config) you can run the [installer](./installer/README.md) container via the shell script wrapper. This will ask for the location of your inventory file and then run through the installation on both your nodes in parallel.
 
+**Linux:**
 ```bash
-# re-directs to the raw install.sh file in this repo
 curl -sL https://bit.ly/ha-install | bash
+```
+
+**macOS:**
+```bash
+curl -sL https://bit.ly/ha-install -o /tmp/install.sh && \
+  chmod +x /tmp/install.sh && \
+  /tmp/install.sh -n
 ```
 
 You should hopefully see something like..

--- a/install.sh
+++ b/install.sh
@@ -20,6 +20,7 @@ playbook="install"
 container_cmd=podman
 manifest_url="https://github.com/davison/ha-sinkhole/releases/download/channel-manifest-artifact/manifest.yaml"
 installer_container=""  # Will be set after parsing inventory and fetching manifest
+native_mode=false
 
 error_exit() {
     printf "${cross_mark} ERROR: $1\n" >&2
@@ -41,8 +42,15 @@ usage() {
     printf "Options:\n"
     printf "  ${bold}-f${reset} <file>   Path to the .yaml or .yml inventory file.\n"
     printf "  ${bold}-c${reset} <cmd>    The command to execute (defaults to 'install').\n"
-    printf "  ${bold}-l${reset}          Use a locally built installer (for development only).\n\n"
+    printf "  ${bold}-l${reset}          Use a locally built installer (for development only).\n"
+    printf "  ${bold}-n${reset}          Run Ansible natively (not in container).\n\n"
     printf "If options are missing, the script will prompt for values at runtime.\n\n"
+    printf "${yellow}macOS Users:${reset}\n"
+    printf "  Use native mode with ${bold}-n${reset} flag (requires: pipx install ansible-core)\n"
+    printf "  Container mode has SSH and permission limitations on macOS.\n\n"
+    printf "${yellow}General Requirements:${reset}\n"
+    printf "  - SSH key authentication configured for target hosts\n"
+    printf "  - Target hosts must have passwordless sudo configured\n\n"
     exit 0
 }
 
@@ -94,7 +102,7 @@ trap 'error_exit "An unknown or unexpected error occurred."' ERR
 
 printf "\n🌐  ${bold}Welcome to ha-sinkhole 🌐${reset}\n\n"
 
-while getopts ":f:c:lh" opt; do
+while getopts ":f:c:lnh" opt; do
     case "${opt}" in
         f)
             inventory_file="${OPTARG}"
@@ -104,6 +112,9 @@ while getopts ":f:c:lh" opt; do
             ;;
         l)
             installer_container="localhost/ha-sinkhole/installer:local"
+            ;;
+        n)
+            native_mode=true
             ;;
         h)
             usage 
@@ -135,6 +146,12 @@ if [[ -z "${SSH_AUTH_SOCK:-}" || ! -S $SSH_AUTH_SOCK ]]; then
     error_exit "${bold}SSH_AUTH_SOCK${reset} is not set or is not accessible. Please ensure your SSH agent is running, your key is added and the environment variable is set."
 fi
 
+# Check if SSH agent has any keys loaded
+if ! ssh-add -l &> /dev/null; then
+    printf "${yellow}⚠${reset}  Warning: No SSH keys found in agent. You may need to run: ${bold}ssh-add ~/.ssh/id_ed25519${reset}\n"
+    printf "   If your target hosts require SSH key authentication, the installation will fail.\n\n"
+fi
+
 # Prompt for inventory file if not provided
 if [[ -z "$inventory_file" || ! -f "$inventory_file" ]]; then
     while true; do
@@ -149,6 +166,11 @@ if [[ -z "$inventory_file" || ! -f "$inventory_file" ]]; then
         inventory_file="$input_file"
         break
     done
+fi
+
+# Convert inventory file path to absolute path for container mounting
+if [[ ! "$inventory_file" = /* ]]; then
+    inventory_file="$(cd "$(dirname "$inventory_file")" && pwd)/$(basename "$inventory_file")"
 fi
 
 # Set installer container version from manifest (unless using local)
@@ -166,21 +188,74 @@ $container_cmd pull "$installer_container" > /dev/null 2>&1 || error_exit "Faile
 logfile=$(mktemp /tmp/ha-sinkhole-log.XXXXXX)
 ok "Running remote ${playbook}, this may take a minute or two. The full log is at ${bold}$logfile${reset}\n"
 
-$container_cmd run \
-    --rm \
-    --net=host \
-    --userns=keep-id \
-    --name ha-sinkhole-installer \
-    -v "$inventory_file":/home/ansible/inventory.yaml \
-    -v "$SSH_AUTH_SOCK":/tmp/ssh-agent.sock \
-    $installer_container \
-    playbooks/"$playbook".yaml > "$logfile" 2>&1 || {
-        error_exit "Installation failed."
+if [[ "$native_mode" == "true" ]]; then
+    # Native mode: run ansible-playbook directly on the host
+    if ! command -v ansible-playbook &> /dev/null; then
+        error_exit "ansible-playbook not found. Install with: ${bold}pipx install ansible-core${reset}"
+    fi
+    
+    # Extract playbook from container to temp directory
+    temp_dir=$(mktemp -d)
+    trap "rm -rf $temp_dir" EXIT
+    
+    $container_cmd create --name ha-sinkhole-installer-temp "$installer_container" > /dev/null
+    $container_cmd cp ha-sinkhole-installer-temp:/home/ansible/. "$temp_dir/"
+    $container_cmd rm ha-sinkhole-installer-temp > /dev/null
+    
+    # Run ansible-playbook natively
+    cd "$temp_dir"
+    ansible-playbook -i "$inventory_file" "playbooks/$playbook.yaml" > "$logfile" 2>&1 || {
+        # Don't exit immediately - let the error checking below provide better messages
+        :
     }
+else
+    # Container mode: run in container
+    # Build container command with platform-specific networking and SSH handling
+    network_args=()
+    ssh_mount_args=()
+    userns_args=()
+
+    if [[ "$(uname)" == "Darwin" ]]; then
+        # macOS: SSH agent sockets from launchd can't be mounted into containers
+        # Mount .ssh directory (note: has limitations, native mode recommended)
+        userns_args=(--userns=keep-id)
+        if [[ -d "$HOME/.ssh" ]]; then
+            ssh_mount_args=(-v "$HOME/.ssh:/home/ansible/.ssh:ro")
+        fi
+    else
+        # Linux: Use host networking and mount SSH agent socket
+        network_args=(--net=host)
+        userns_args=(--userns=keep-id)
+        if [[ -n "${SSH_AUTH_SOCK:-}" && -S "$SSH_AUTH_SOCK" ]]; then
+            ssh_mount_args=(-v "$SSH_AUTH_SOCK:/tmp/ssh-agent.sock")
+        fi
+    fi
+
+    $container_cmd run \
+        --rm \
+        ${network_args[@]+"${network_args[@]}"} \
+        ${userns_args[@]+"${userns_args[@]}"} \
+        --name ha-sinkhole-installer \
+        -v "$inventory_file":/home/ansible/inventory.yaml \
+        ${ssh_mount_args[@]+"${ssh_mount_args[@]}"} \
+        $installer_container \
+        playbooks/"$playbook".yaml > "$logfile" 2>&1 || {
+            # Don't exit immediately - let the error checking below provide better messages
+            :
+        }
+fi
 
 # check common issues
 if grep -q "UNREACHABLE!" "${logfile}"; then
-    error_exit "Some hosts were unreachable during installation."
+    if [[ "$(uname)" == "Darwin" ]] && grep -q "Permission denied" "${logfile}"; then
+        # macOS-specific SSH auth issue
+        printf "${cross_mark} ERROR: SSH authentication failed.\n" >&2
+        printf "\n${yellow}macOS:${reset} Container mode has SSH authentication limitations.\n" >&2
+        printf "  Use native mode: ${bold}$0 -f $inventory_file -n${reset}\n\n" >&2
+    else
+        error_exit "Some hosts were unreachable during installation."
+    fi
+    exit 1
 fi
 if grep -q "FAILED!" "${logfile}"; then
     error_exit "Some tasks failed during installation."
@@ -189,7 +264,11 @@ if grep -q "Unable to parse /home/ansible/inventory.yaml" "${logfile}"; then
     error_exit "Inventory could not be parsed, please check your ${bold}${inventory_file}${reset} file."
 fi
 
-awk '/PLAY RECAP/{p=1; next} p' ${logfile}
-ok "Success! 🎉\n"
-
-exit 0
+# If we get here and there were errors, show a generic message
+if grep -q "failed=0" "${logfile}" && grep -q "unreachable=0" "${logfile}"; then
+    awk '/PLAY RECAP/{p=1; next} p' ${logfile}
+    ok "Success! 🎉\n"
+    exit 0
+else
+    error_exit "Installation completed with errors. Check the log for details."
+fi


### PR DESCRIPTION
Container mode SSH authentication changed on macOS

Add native mode (-n flag) to run Ansible directly on host, bypassing
container limitations on macOS. This addresses multiple macOS-specific
issues:

- Fix bash 3.2 compatibility by replacing ${var,,} with tr command
- Add relative-to-absolute path conversion for inventory mounting
- Implement native mode that extracts playbooks and runs locally
- Add macOS-specific error detection for SSH authentication failures
- Mount .ssh directory instead of launchd socket in container mode
- Add platform-specific usage guidance and warnings
- Improve error messages with actionable remediation steps

Container mode on macOS now has documented limitations and users are
directed to use native mode which requires ansible-core installed via
pipx in a python venv.
